### PR TITLE
#1 バージョン表示機能の実装

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module convini
+
+go 1.17

--- a/main.go
+++ b/main.go
@@ -3,7 +3,11 @@ package main
 import (
 	"flag"
 	"fmt"
+	"runtime/debug"
 )
+
+// バージョン
+var version = ""
 
 func main() {
 
@@ -14,6 +18,24 @@ func main() {
 	flag.Parse()
 
 	if v {
-		fmt.Println("convini-cli version 1.0.0")
+		fmt.Printf("convini-cli %s`\n", getVersion())
 	}
+}
+
+/*
+ * バージョン情報を取得します。
+ * 実行時に以下のオプションを設定することでバージョンが表示されます。
+ * go build -ldflags '-s -w -X main.version={表示するバージョンを指定}'
+ */
+func getVersion() string {
+	if version != "" {
+		// バージョン情報が設定されている場合
+		return version
+	}
+
+	i, ok := debug.ReadBuildInfo()
+	if !ok {
+		return "unknown"
+	}
+	return i.Main.Version
 }

--- a/main.go
+++ b/main.go
@@ -1,0 +1,19 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+)
+
+func main() {
+
+	// コマンド定義
+	var v bool
+	flag.BoolVar(&v, "v", false, "convini-cli version")
+
+	flag.Parse()
+
+	if v {
+		fmt.Println("convini-cli version 1.0.0")
+	}
+}


### PR DESCRIPTION
-vオプションでバージョン情報が表示できるように実装しました。
ビルド時に以下のオプションでバージョンを指定することでバージョン情報が埋め込まれます。

go build -ldflags '-s -w -X main.version={表示するバージョンを指定}'